### PR TITLE
Support charset in sourcemap data URIs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const regex1 = new RegExp(`/\\*${baseRegex}\\s*\\*/`);
 // Matches // .... comments
 const regex2 = new RegExp(`//${baseRegex}($|\n|\r\n?)`);
 // Matches DataUrls
-const regexDataUrl = /data:[^;\n]+;base64,(.*)/;
+const regexDataUrl = /data:[^;\n]+;(?:charset=utf8;)?base64,(.*)/;
 
 module.exports = function(input, inputMap) {
   this.cacheable && this.cacheable();


### PR DESCRIPTION
We noticed that the inline sourcemaps created by TypeScript 2.1 include a charset, which was failing the regex lookup on the data URI.

This allows for a `charset=utf8;` to be included in the sourcemap data URI while still matching sourcemaps without it.