### PR TITLE
Safer charset parsing for inline source maps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const regex1 = new RegExp(`/\\*${baseRegex}\\s*\\*/`);
 // Matches // .... comments
 const regex2 = new RegExp(`//${baseRegex}($|\n|\r\n?)`);
 // Matches DataUrls
-const regexDataUrl = /data:[^;\n]+;(?:charset=utf8;)?base64,(.*)/;
+const regexDataUrl = /data:[^;\n]+;(?:charset=[^;\n]+;)?base64,(.*)/;
 
 module.exports = function(input, inputMap) {
   this.cacheable && this.cacheable();


### PR DESCRIPTION
This should handle any charset, not restricting it to `utf8` (which didn't match `utf-8`).