### PR TITLE
Don't match source map declaration generators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const loaderUtils = require('loader-utils');
 
 const baseRegex = '\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)';
 // Matches /* ... */ comments
-const regex1 = new RegExp(`/\\*${baseRegex}\\s*\\*/`);
+const regex1 = new RegExp(`/^\\/\\*${baseRegex}\\s*\\*\\/$/`);
 // Matches // .... comments
 const regex2 = new RegExp(`//${baseRegex}($|\n|\r\n?)`);
 // Matches DataUrls


### PR DESCRIPTION
Matching only the comment format causes parse failures when handling code with functions for generating source maps, like https://github.com/webpack/style-loader/blob/master/addStyles.js#L235.